### PR TITLE
Allow for synchronous-style usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ s3Logs.parse(rawLog, function(parsed) {
   // parsed = [{}, {}]
 });
 ```
+
+or the callback may be omitted and the return value used:
+
+```javascript
+var parsed = s3Logs.parse(rawLog);
+```
+
+
 Each newline on the raw data, a new object it's added to the array. Here's an example of what it's returned:
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -72,7 +72,13 @@ exports.parse = function (log, callback) {
     if (turnAroundTime !== '-') formatted['turnAroundTime'] = +turnAroundTime;
 
     parsed.push(formatted);
-    if (i + 1 === logs.length) callback(parsed);
+    if (i + 1 === logs.length) {
+      if (callback) {
+        callback(parsed);
+      } else {
+        return parsed;
+      }
+    }
   }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,3 +5,6 @@ var sampleLog = require('./sample');
 s3LogParser.parse(sampleLog, function (parsed) {
   assert.equal(parsed.length, 7);
 });
+
+// Alternate usage style.
+assert.equal(s3LogParser.parse(sampleLog).length, 7);


### PR DESCRIPTION
There’s nothing asynchronous about how the function works, so a more conventional return style would be convenient.